### PR TITLE
Preserve newlines in match output

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -158,7 +158,7 @@ export default function RegexBuilderApp() {
             <Section title="Test against a string">
               <div className="space-y-3">
                 <textarea className="input min-h-[120px]" value={testText} onChange={(e) => setTestText(e.target.value)} />
-                <div className="bg-slate-800/60 border border-slate-700 rounded-xl p-3 text-base leading-relaxed">
+                <div className="bg-slate-800/60 border border-slate-700 rounded-xl p-3 text-base leading-relaxed whitespace-pre-wrap">
                   {highlightText(testText, matches.map((m) => ({ start: m.start, end: m.end })))}
                 </div>
                 <div className="text-sm text-slate-300">


### PR DESCRIPTION
## Summary
- keep highlighted match section's newline formatting with `whitespace-pre-wrap`

## Testing
- `npm run build`
- `node --input-type=module - <<'NODE'
const highlightText = (text, ranges) => {
  if (ranges.length === 0) return [text];
  const out = [];
  let idx = 0;
  ranges.sort((a,b)=>a.start-b.start);
  for (const r of ranges) {
    if (idx < r.start) out.push(text.slice(idx, r.start));
    out.push(`[${text.slice(r.start, r.end)}]`);
    idx = r.end;
  }
  if (idx < text.length) out.push(text.slice(idx));
  return out.join('');
};
const text = 'line1\nline2';
const ranges = [{start:0,end:5},{start:6,end:11}];
console.log(highlightText(text, ranges));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68aaebf5b1d88332acee8e5522bde3f6