### PR TITLE
feat: add regex import and parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@dnd-kit/sortable": "^10.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "regexp-tree": "^0.1.27"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
@@ -21,7 +22,8 @@
         "gh-pages": "^6.3.0",
         "postcss": "^8.4.41",
         "tailwindcss": "^3.4.10",
-        "vite": "^5.4.19"
+        "vite": "^5.4.19",
+        "vitest": "^1.6.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -750,6 +752,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1096,6 +1111,13 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1163,6 +1185,122 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
@@ -1220,6 +1358,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/async": {
@@ -1337,6 +1485,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1365,6 +1523,38 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1436,6 +1626,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1485,11 +1682,34 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1590,6 +1810,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/fast-glob": {
@@ -1777,6 +2031,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gh-pages": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
@@ -1882,6 +2159,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1956,6 +2243,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -2048,6 +2348,23 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2072,6 +2389,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2079,6 +2406,16 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -2096,6 +2433,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2117,6 +2461,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2142,6 +2499,26 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2202,6 +2579,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2218,6 +2624,22 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -2322,6 +2744,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2370,6 +2809,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -2514,6 +2972,34 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2566,6 +3052,13 @@
         "react": "*"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2594,6 +3087,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/resolve": {
@@ -2726,6 +3228,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2756,6 +3265,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -2852,6 +3375,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-outer": {
       "version": "1.0.1",
@@ -2958,6 +3514,33 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2994,6 +3577,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -3101,6 +3701,95 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3114,6 +3803,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -3223,6 +3929,19 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "test": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "regexp-tree": "^0.1.27"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
@@ -25,6 +27,7 @@
     "gh-pages": "^6.3.0",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.6.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ Drag-and-drop regular expression builder built with React + Vite.
   - Username
   - Password
 - Copy regex to clipboard
+- Import existing regex patterns
 
 ## Tech Stack
 - React 18
@@ -61,7 +62,8 @@ npm run preview # locally preview production build
 2. Edit blocks to fine-tune patterns.
 3. Toggle regex flags.
 4. Apply templates for common patterns.
-5. Copy the resulting regex to your clipboard.
+5. Use the Import button to load an existing pattern.
+6. Copy the resulting regex to your clipboard.
 
 ## Contributing
 Issues and pull requests welcome. Feel free to contribute!

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -21,6 +21,7 @@ import TemplateDropdown from "./components/TemplateDropdown.jsx";
 import { nodeToPattern, summarizeNode, computeMatches, highlightText } from "./utils/regex.jsx";
 import { makeAnchor, makeLiteral } from "./utils/nodes.js";
 import { FaEdit, FaTrash, FaRedo, FaGripVertical } from "react-icons/fa";
+import ImportRegexModal from "./components/ImportRegexModal.jsx";
 
 export default function RegexBuilderApp() {
   const [nodes, setNodes] = useState([makeAnchor("start"), makeLiteral(), makeAnchor("end")]);
@@ -28,6 +29,7 @@ export default function RegexBuilderApp() {
   const [testText, setTestText] = useState("Try your regex here. For example, test 123, test 456.");
   const [showExplain, setShowExplain] = useState(true);
   const [modalNode, setModalNode] = useState(null);
+  const [showImport, setShowImport] = useState(false);
 
   const applyTemplate = ({ nodes, flags, testText }) => {
     setNodes(nodes);
@@ -102,6 +104,7 @@ export default function RegexBuilderApp() {
           <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Regex Builder</h1>
           <div className="flex items-center gap-2 flex-wrap">
             <TemplateDropdown templates={templates} onSelect={applyTemplate} />
+            <button className="pill" onClick={() => setShowImport(true)}>Import regex</button>
             <button
               className="pill"
               onClick={() => {
@@ -216,6 +219,15 @@ export default function RegexBuilderApp() {
         <Modal title={`Edit block #${modalNode.idx + 1}`} onClose={() => setModalNode(null)}>
           <NodeEditor node={nodes[modalNode.idx]} onChange={(n) => updateNode(modalNode.idx, n)} />
         </Modal>
+      )}
+      {showImport && (
+        <ImportRegexModal
+          onClose={() => setShowImport(false)}
+          onImport={({ nodes: n, flags: f }) => {
+            setNodes(n);
+            setFlags(f);
+          }}
+        />
       )}
 
       <footer className="max-w-7xl mx-auto px-4 pb-10 pt-4 text-xs text-slate-400">

--- a/src/components/ImportRegexModal.jsx
+++ b/src/components/ImportRegexModal.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { Modal } from "./ui.jsx";
+import { parseRegex } from "../utils/regex.jsx";
+
+export default function ImportRegexModal({ onClose, onImport }) {
+  const [pattern, setPattern] = useState("");
+  const [flags, setFlags] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    try {
+      const res = parseRegex(pattern, flags);
+      onImport(res);
+      onClose();
+    } catch (err) {
+      setError(err?.message || String(err));
+    }
+  };
+
+  return (
+    <Modal title="Import regex" onClose={onClose}>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-slate-300">Pattern</label>
+          <input className="input" value={pattern} onChange={(e) => setPattern(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-slate-300">Flags</label>
+          <input className="input" value={flags} onChange={(e) => setFlags(e.target.value)} />
+        </div>
+        {error && <div className="text-sm text-rose-400">{error}</div>}
+        <div className="flex items-center gap-2 justify-end">
+          <button type="button" className="pill" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit" className="btn">
+            Import
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/utils/nodes.js
+++ b/src/utils/nodes.js
@@ -18,7 +18,13 @@ export const makeCharClass = () => ({
   quant: { kind: "one" },
 });
 export const makeGroup = () => ({ id: uid(), type: "group", capturing: true, nodes: [], quant: { kind: "one" } });
-export const makeAlt = () => ({ id: uid(), type: "alternation", branches: [[]], quant: { kind: "one" } });
+export const makeAlt = () => ({
+  id: uid(),
+  type: "alternation",
+  branches: [[]],
+  quant: { kind: "one" },
+  grouped: true,
+});
 export const makeLook = () => ({ id: uid(), type: "look", direction: "ahead", positive: true, nodes: [], quant: { kind: "one" } });
 export const makeBackref = () => ({ id: uid(), type: "backref", ref: { index: 1 }, quant: { kind: "one" } });
 

--- a/src/utils/nodes.js
+++ b/src/utils/nodes.js
@@ -6,7 +6,7 @@ export const makeLiteral = () => ({ id: uid(), type: "literal", text: "abc", qua
 export const makePredef = (which) => ({ id: uid(), type: "predef", which, quant: { kind: "one" } });
 export const makeAnchor = (which) => ({ id: uid(), type: "anchor", which });
 export const makeBoundary = (which) => ({ id: uid(), type: "boundary", which, quant: { kind: "one" } });
-export const makeCharClass = () => ({ id: uid(), type: "charclass", payload: { negate: false, sets: { az: false, AZ: false, d09: true, underscore: false, whitespace: false }, custom: "" }, quant: { kind: "one" } });
+export const makeCharClass = () => ({ id: uid(), type: "charclass", payload: { negate: false, sets: { az: false, AZ: false, d09: false, underscore: false, whitespace: false }, custom: "" }, quant: { kind: "one" } });
 export const makeGroup = () => ({ id: uid(), type: "group", capturing: true, nodes: [], quant: { kind: "one" } });
 export const makeAlt = () => ({ id: uid(), type: "alternation", branches: [[]], quant: { kind: "one" } });
 export const makeLook = () => ({ id: uid(), type: "look", direction: "ahead", positive: true, nodes: [], quant: { kind: "one" } });

--- a/src/utils/nodes.js
+++ b/src/utils/nodes.js
@@ -6,7 +6,17 @@ export const makeLiteral = () => ({ id: uid(), type: "literal", text: "abc", qua
 export const makePredef = (which) => ({ id: uid(), type: "predef", which, quant: { kind: "one" } });
 export const makeAnchor = (which) => ({ id: uid(), type: "anchor", which });
 export const makeBoundary = (which) => ({ id: uid(), type: "boundary", which, quant: { kind: "one" } });
-export const makeCharClass = () => ({ id: uid(), type: "charclass", payload: { negate: false, sets: { az: false, AZ: false, d09: false, underscore: false, whitespace: false }, custom: "" }, quant: { kind: "one" } });
+export const makeCharClass = () => ({
+  id: uid(),
+  type: "charclass",
+  payload: {
+    negate: false,
+    sets: { az: false, AZ: false, d09: false, underscore: false, whitespace: false },
+    custom: "",
+    raw: "",
+  },
+  quant: { kind: "one" },
+});
 export const makeGroup = () => ({ id: uid(), type: "group", capturing: true, nodes: [], quant: { kind: "one" } });
 export const makeAlt = () => ({ id: uid(), type: "alternation", branches: [[]], quant: { kind: "one" } });
 export const makeLook = () => ({ id: uid(), type: "look", direction: "ahead", positive: true, nodes: [], quant: { kind: "one" } });

--- a/src/utils/regex.jsx
+++ b/src/utils/regex.jsx
@@ -80,7 +80,11 @@ export const nodeToPattern = (n) => {
     }
     case "alternation": {
       const branches = n.branches.map((b) => b.map(nodeToPattern).join("")).join("|");
-      return `(?:${branches})${quantToString(n.quant)}`;
+      const quant = quantToString(n.quant);
+      if (n.grouped || quant) {
+        return `(?:${branches})${quant}`;
+      }
+      return branches;
     }
     case "look": {
       const inner = n.nodes.map(nodeToPattern).join("");
@@ -267,6 +271,7 @@ export const parseRegex = (pattern, flags = "") => {
         };
         collect(node);
         const alt = makeAlt();
+        alt.grouped = false;
         alt.branches = branches.map((b) => (Array.isArray(b) ? b : b));
         return [alt];
       }

--- a/src/utils/regex.jsx
+++ b/src/utils/regex.jsx
@@ -1,6 +1,19 @@
 // Regex utilities and rendering helpers (JSX)
 
-export const escapeLiteral = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, (m) => `\\${m}`);
+import { parse as parseAst, generate } from "regexp-tree";
+import {
+  makeLiteral,
+  makePredef,
+  makeAnchor,
+  makeBoundary,
+  makeCharClass,
+  makeGroup,
+  makeAlt,
+  makeLook,
+  makeBackref,
+} from "./nodes.js";
+
+export const escapeLiteral = (s) => s.replace(/[.*+?^${}()|[\\]\\]/g, (m) => `\\${m}`);
 
 export const escapeCharClass = (s) => s.replace(/[\\\]\-^]/g, (m) => `\\${m}`); // escape \\ ] - ^ inside []
 
@@ -149,5 +162,173 @@ export const highlightText = (text, ranges) => {
   }
   if (idx < text.length) out.push(<span key={`t-${idx}`}>{text.slice(idx)}</span>);
   return out;
+};
+
+// Parse a regex pattern/flags into the app's node representation
+export const parseRegex = (pattern, flags = "") => {
+  const flagObj = { g: false, i: false, m: false, s: false, u: false, y: false };
+  for (const f of flags) if (flagObj.hasOwnProperty(f)) flagObj[f] = true;
+
+  const ast = parseAst(new RegExp(pattern, flags));
+
+  const quantFrom = (q) => {
+    if (!q) return { kind: "one" };
+    const greedy = q.greedy !== false;
+    switch (q.kind) {
+      case "+":
+        return { kind: "oneOrMore", greedy };
+      case "*":
+        return { kind: "zeroOrMore", greedy };
+      case "?":
+        return { kind: "zeroOrOne", greedy };
+      case "Range":
+        if (q.from === q.to) return { kind: "exact", n: q.from, greedy };
+        if (q.to === undefined || q.to === null) return { kind: "atLeast", n: q.from, greedy };
+        return { kind: "range", min: q.from, max: q.to, greedy };
+      default:
+        return { kind: "one" };
+    }
+  };
+
+  const convertCharClass = (n) => {
+    const cc = makeCharClass();
+    let body = generate(n);
+    if (body.startsWith("[")) body = body.slice(1, -1);
+    if (body.startsWith("^")) {
+      cc.payload.negate = true;
+      body = body.slice(1);
+    }
+    const remove = (token) => {
+      if (body.includes(token)) {
+        body = body.replace(token, "");
+        return true;
+      }
+      return false;
+    };
+    if (remove("a-z")) cc.payload.sets.az = true;
+    if (remove("A-Z")) cc.payload.sets.AZ = true;
+    if (remove("0-9")) cc.payload.sets.d09 = true;
+    if (remove("_")) cc.payload.sets.underscore = true;
+    if (remove("\\s")) cc.payload.sets.whitespace = true;
+    cc.payload.custom = body;
+    return cc;
+  };
+
+  const convert = (node) => {
+    switch (node.type) {
+      case "Alternative":
+        return convertSeq(node.expressions);
+      case "Char": {
+        if (node.kind === "meta") {
+          const map = {
+            "\\d": "digit",
+            "\\D": "nondigit",
+            "\\w": "word",
+            "\\W": "nonword",
+            "\\s": "space",
+            "\\S": "nonspace",
+            ".": "any",
+          };
+          const which = map[node.value];
+          if (which) return [makePredef(which)];
+        }
+        const lit = makeLiteral();
+        lit.text = node.value;
+        return [lit];
+      }
+      case "Repetition": {
+        const [child] = convert(node.expression);
+        child.quant = quantFrom(node.quantifier);
+        return [child];
+      }
+      case "Group": {
+        const g = makeGroup();
+        g.capturing = node.capturing !== false;
+        if (node.name) g.name = node.name;
+        g.nodes = node.expression ? convert(node.expression) : [];
+        return [g];
+      }
+      case "Disjunction": {
+        const branches = [];
+        const collect = (n) => {
+          if (n.type === "Disjunction") {
+            collect(n.left);
+            collect(n.right);
+          } else if (n.type === "Alternative") {
+            branches.push(convertSeq(n.expressions));
+          } else {
+            branches.push(convert(n));
+          }
+        };
+        collect(node);
+        const alt = makeAlt();
+        alt.branches = branches.map((b) => (Array.isArray(b) ? b : b));
+        return [alt];
+      }
+      case "Assertion": {
+        if (node.kind === "^") return [makeAnchor("start")];
+        if (node.kind === "$") return [makeAnchor("end")];
+        if (node.kind === "\\b") return [makeBoundary("word")];
+        if (node.kind === "\\B") return [makeBoundary("nonword")];
+        if (node.kind === "Lookahead" || node.kind === "Lookbehind") {
+          const look = makeLook();
+          look.direction = node.kind === "Lookahead" ? "ahead" : "behind";
+          look.positive = !node.negative;
+          look.nodes = node.assertion ? convert(node.assertion) : [];
+          return [look];
+        }
+        return [];
+      }
+      case "CharacterClass": {
+        return [convertCharClass(node)];
+      }
+      case "Backreference": {
+        const br = makeBackref();
+        br.ref = node.kind === "name" ? { name: node.reference } : { index: node.reference };
+        return [br];
+      }
+      default:
+        return [];
+    }
+  };
+
+  const convertSeq = (exprs) => {
+    const out = [];
+    let buf = "";
+    const flush = () => {
+      if (buf) {
+        const lit = makeLiteral();
+        lit.text = buf;
+        out.push(lit);
+        buf = "";
+      }
+    };
+    for (const e of exprs) {
+      if (e.type === "Char" && e.kind === "simple") {
+        buf += e.value;
+        continue;
+      }
+      if (
+        e.type === "Repetition" &&
+        e.expression.type === "Char" &&
+        e.expression.kind === "simple"
+      ) {
+        flush();
+        const lit = makeLiteral();
+        lit.text = e.expression.value;
+        lit.quant = quantFrom(e.quantifier);
+        out.push(lit);
+        continue;
+      }
+      flush();
+      out.push(...convert(e));
+    }
+    flush();
+    return out;
+  };
+
+  const body = ast.body;
+  const nodes = body.type === "Alternative" ? convertSeq(body.expressions) : convert(body);
+  return { nodes, flags: flagObj };
 };
 

--- a/src/utils/regex.jsx
+++ b/src/utils/regex.jsx
@@ -40,6 +40,9 @@ export const quantToString = (q) => {
 export const predefToString = (p) => ({ digit: "\\d", nondigit: "\\D", word: "\\w", nonword: "\\W", space: "\\s", nonspace: "\\S", any: "." }[p]);
 
 export const renderCharClass = (cc) => {
+  if (cc.raw) {
+    return `[${cc.negate ? "^" : ""}${cc.raw}]`;
+  }
   const parts = [];
   if (cc.sets.az) parts.push("a-z");
   if (cc.sets.AZ) parts.push("A-Z");
@@ -198,6 +201,7 @@ export const parseRegex = (pattern, flags = "") => {
       cc.payload.negate = true;
       body = body.slice(1);
     }
+    const rawBody = body;
     const remove = (token) => {
       if (body.includes(token)) {
         body = body.replace(token, "");
@@ -211,6 +215,7 @@ export const parseRegex = (pattern, flags = "") => {
     if (remove("_")) cc.payload.sets.underscore = true;
     if (remove("\\s")) cc.payload.sets.whitespace = true;
     cc.payload.custom = body;
+    cc.payload.raw = rawBody;
     return cc;
   };
 

--- a/src/utils/regex.parse.test.js
+++ b/src/utils/regex.parse.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { parseRegex } from "./regex.jsx";
+
+const strip = (nodes) =>
+  nodes.map(({ id, nodes, branches, ...rest }) => ({
+    ...rest,
+    ...(nodes ? { nodes: strip(nodes) } : {}),
+    ...(branches ? { branches: branches.map(strip) } : {}),
+  }));
+
+describe("parseRegex", () => {
+  it("parses literals", () => {
+    const { nodes } = parseRegex("abc", "");
+    expect(strip(nodes)).toEqual([
+      { type: "literal", text: "abc", quant: { kind: "one" } },
+    ]);
+  });
+
+  it("parses groups and alternation", () => {
+    const { nodes } = parseRegex("(a|b)", "");
+    expect(strip(nodes)).toEqual([
+      {
+        type: "group",
+        capturing: true,
+        nodes: [
+          {
+            type: "alternation",
+            branches: [[{ type: "literal", text: "a", quant: { kind: "one" } }], [{ type: "literal", text: "b", quant: { kind: "one" } }]],
+            quant: { kind: "one" },
+          },
+        ],
+        quant: { kind: "one" },
+      },
+    ]);
+  });
+
+  it("parses quantifiers", () => {
+    const { nodes } = parseRegex("a{2,3}", "");
+    expect(strip(nodes)).toEqual([
+      { type: "literal", text: "a", quant: { kind: "range", min: 2, max: 3, greedy: true } },
+    ]);
+  });
+
+  it("parses lookarounds", () => {
+    const { nodes } = parseRegex("(?=a)b", "");
+    expect(strip(nodes)).toEqual([
+      {
+        type: "look",
+        direction: "ahead",
+        positive: true,
+        nodes: [{ type: "literal", text: "a", quant: { kind: "one" } }],
+        quant: { kind: "one" },
+      },
+      { type: "literal", text: "b", quant: { kind: "one" } },
+    ]);
+  });
+});

--- a/src/utils/regex.parse.test.js
+++ b/src/utils/regex.parse.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseRegex } from "./regex.jsx";
+import { parseRegex, nodeToPattern } from "./regex.jsx";
 
 const strip = (nodes) =>
   nodes.map(({ id, nodes, branches, ...rest }) => ({
@@ -66,5 +66,12 @@ describe("parseRegex", () => {
       underscore: false,
       whitespace: false,
     });
+  });
+
+  it("preserves complex character class ranges", () => {
+    const pattern = "([13][a-km-zA-HJ-NP-Z0-9]{26,33})";
+    const { nodes } = parseRegex(pattern, "g");
+    const round = nodes.map(nodeToPattern).join("");
+    expect(round).toEqual(pattern);
   });
 });

--- a/src/utils/regex.parse.test.js
+++ b/src/utils/regex.parse.test.js
@@ -54,4 +54,17 @@ describe("parseRegex", () => {
       { type: "literal", text: "b", quant: { kind: "one" } },
     ]);
   });
+
+  it("parses character classes without adding digits", () => {
+    const { nodes } = parseRegex("([A-Z])\\w+", "");
+    const group = nodes[0];
+    const cc = group.nodes[0];
+    expect(cc.payload.sets).toEqual({
+      az: false,
+      AZ: true,
+      d09: false,
+      underscore: false,
+      whitespace: false,
+    });
+  });
 });

--- a/src/utils/regex.parse.test.js
+++ b/src/utils/regex.parse.test.js
@@ -27,6 +27,7 @@ describe("parseRegex", () => {
             type: "alternation",
             branches: [[{ type: "literal", text: "a", quant: { kind: "one" } }], [{ type: "literal", text: "b", quant: { kind: "one" } }]],
             quant: { kind: "one" },
+            grouped: false,
           },
         ],
         quant: { kind: "one" },
@@ -70,6 +71,14 @@ describe("parseRegex", () => {
 
   it("preserves complex character class ranges", () => {
     const pattern = "([13][a-km-zA-HJ-NP-Z0-9]{26,33})";
+    const { nodes } = parseRegex(pattern, "g");
+    const round = nodes.map(nodeToPattern).join("");
+    expect(round).toEqual(pattern);
+  });
+
+  it("does not add non-capturing groups around alternation", () => {
+    const pattern =
+      "^((?=.*[\\d])(?=.*[a-z])(?=.*[A-Z])|(?=.*[a-z])(?=.*[A-Z])(?=.*[^\\w\\d\\s])|(?=.*[\\d])(?=.*[A-Z])(?=.*[^\\w\\d\\s])|(?=.*[\\d])(?=.*[a-z])(?=.*[^\\w\\d\\s])).{7,30}$";
     const { nodes } = parseRegex(pattern, "g");
     const round = nodes.map(nodeToPattern).join("");
     expect(round).toEqual(pattern);


### PR DESCRIPTION
## Summary
- parse regular expressions using `regexp-tree` and map to app nodes
- add ImportRegexModal and hook into main app
- document new import feature and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4f66afa88332be57e48695064d44