### PR TITLE
Add explanation tree and accordion explanation view

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -19,6 +19,7 @@ import { NodeEditor } from "./components/editors/NodeEditors.jsx";
 import { templates } from "./templates/index.js";
 import TemplateDropdown from "./components/TemplateDropdown.jsx";
 import { nodeToPattern, summarizeNode, computeMatches, highlightText } from "./utils/regex.jsx";
+import Explanation from "./components/Explanation.jsx";
 import { makeAnchor, makeLiteral } from "./utils/nodes.js";
 import { FaEdit, FaTrash, FaRedo, FaGripVertical } from "react-icons/fa";
 import ImportRegexModal from "./components/ImportRegexModal.jsx";
@@ -95,8 +96,6 @@ export default function RegexBuilderApp() {
     }
   };
 
-  const explain = () => nodes.map((n, i) => `${i + 1}. ${summarizeNode(n)}`).join("\n");
-
   return (
     <div className="min-h-screen w-full bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 text-slate-100">
       <div className="max-w-7xl mx-auto px-4 py-6">
@@ -151,8 +150,8 @@ export default function RegexBuilderApp() {
                 </div>
 
                 {showExplain && (
-                  <div className="bg-slate-900/60 border border-slate-800 rounded-xl p-3 text-sm text-slate-300 whitespace-pre-wrap">
-                    {nodes.length ? explain() : "Add blocks to see an explanation."}
+                  <div className="bg-slate-900/60 border border-slate-800 rounded-xl p-3 text-sm text-slate-300">
+                    {nodes.length ? <Explanation nodes={nodes} /> : "Add blocks to see an explanation."}
                   </div>
                 )}
               </div>

--- a/src/components/Explanation.jsx
+++ b/src/components/Explanation.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import { describeNodeTree } from "../utils/regex.jsx";
+
+const TreeNode = ({ node, defaultOpen = false }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const hasChildren = node.children && node.children.length > 0;
+  return (
+    <div className="ml-2">
+      <div className="flex items-center gap-1">
+        {hasChildren && (
+          <button
+            className="text-xs text-slate-400"
+            onClick={() => setOpen(!open)}
+          >
+            {open ? "▼" : "▶"}
+          </button>
+        )}
+        <span>{node.label}</span>
+      </div>
+      {hasChildren && open && (
+        <div className="ml-4 border-l border-slate-700 pl-2">
+          {node.children.map((c) => (
+            <TreeNode key={c.id} node={c} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default function Explanation({ nodes }) {
+  const tree = nodes.map(describeNodeTree);
+  return (
+    <div className="space-y-1">
+      {tree.map((n) => (
+        <TreeNode key={n.id} node={n} defaultOpen />
+      ))}
+    </div>
+  );
+}

--- a/src/utils/regex.jsx
+++ b/src/utils/regex.jsx
@@ -129,6 +129,21 @@ export const summarizeNode = (n) => {
   }
 };
 
+// Build a description tree for a node and its children
+export const describeNodeTree = (node) => {
+  const item = { id: node.id, label: summarizeNode(node) };
+  if (node.type === "group" || node.type === "look") {
+    item.children = node.nodes.map(describeNodeTree);
+  } else if (node.type === "alternation") {
+    item.children = node.branches.map((branch, i) => ({
+      id: `${node.id}-b${i}`,
+      label: `Option ${i + 1}`,
+      children: branch.map(describeNodeTree),
+    }));
+  }
+  return item;
+};
+
 export const defaultQuant = { kind: "one" };
 
 export const computeMatches = (pattern, flags, text) => {


### PR DESCRIPTION
## Summary
- build `describeNodeTree` to preserve child structure for groups and alternations
- add `Explanation` component with collapsible group sections
- integrate `Explanation` into main app, replacing string-based explanation

## Testing
- `npx vitest run`
- `npx vite-node /tmp/test-desc.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab62bd34a08332b51c760dc57ac665